### PR TITLE
Customizable footer layout

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,7 +47,8 @@ babel-otherlangs:
 
 colorlinks: true # Colorize links, useful for the digital version
 
-roman-numerals: true # Use roman numerals for content tables
+pagemark-roman: true # Use roman numerals for all pagemarks
+# index-roman: true # Use roman numerals for indices in content tables
 
 footer:
   pagemark:  # Determine where the page counter is located, default is center, options are right & left

--- a/index.md
+++ b/index.md
@@ -49,6 +49,11 @@ colorlinks: true # Colorize links, useful for the digital version
 
 roman-numerals: true # Use roman numerals for content tables
 
+footer:
+  pagemark:  # Determine where the page counter is located, default is center, options are right & left
+    left: true
+  authors: true # Include authors in footer, away from the pagemark.
+
 # lot: true # Enable list of tables
 # lof: true # Enable list of figures
 # lol: true # Enable list of listings

--- a/index.md
+++ b/index.md
@@ -92,49 +92,52 @@ Unter Windows kann sich der entsprechende Befehl aus dem `Makefile` entnommen we
 
 ### Windows
 
-Start powershell
+Im folgenden wird die installation unter Windows beschrieben. Zunächst öffnen wir eine Powershell Sitzung, vorzüglich [pwsh](https://github.com/powershell/powershell), denn die Microsoft proprietäre Implementierung ist besonders. 
 
-**If scoop is not installed**
+Als package-manager wird scoop genutzt, denn der benötigt keine administrativen Rechte.
 ```pwsh
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 irm get.scoop.sh | iex
 ```
 
-**If python is not installed**
+Mit Pip werden die nicht auf scoop auffindbaren packages installiert.
 ```pwsh
 scoop install python
 python -m ensure pip
 ```
 
-**If GNU make is not available** (Rust implementation of GNU core utils)
+Zu gut der Letzt benötigen wir noch Makefiles `make` command aus den GNU core utils. Hier verwenden wir die Rust Implementation.
 ```pwsh
 scoop install uutils-coreutils
 ```
 
-Now for the actual installation execute the following commands (tinytex ist a texlive distribution)
+Jetzt werden die `pandoc` Abhängigkeiten und eine Latex engine, hier `tinytex` eine `texlive` distribution, eingesetzt. Der nicht Konsolen-Freund sollte anstatt `tinytex` [MikTex](https://miktex.org/howto/install-miktex) als Benutzer installieren, das macht das verwalten von LaTex packages angenehmer.
+
 ```pwsh 
+# texlive installation
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
-scoop install tinytex pandoc pandoc-crossref
+scoop install tinytex
+# pandoc installation
+scoop install pandoc pandoc-crossref
 pip install pandoc-acro pandoc-include --user
 ```
 
 ### Linux
 
-Start terminal
-
-**If homebrew is not installed**
+Zunächst den [homebrew](https://brew.sh/) ~~package~~-manager installieren.
 ```bash
-test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)"
-test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-test -r ~/.bash_profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bash_profile
-echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.profile
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-Now for the actual installation execute the following commands
+Falls `pip` nicht installiert ist `python` `pip` beziehen. `python3` ist manchmal auch nur `python` o.ä. kommt auf Eur setup an.
 ```bash
-python -m ensure pip
-brew install pandoc-crossref texlive
-pip install pandoc pandoc-acro pandoc-include--user
+python3 -m ensure pip
+```
+
+Zu gut der Letzt können die [pandoc](https://pandoc.org/) Abhängigkeiten und die [texlive](https://tug.org/texlive/) LaTex engine installiert werden.
+```bash
+brew install pandoc pandoc-crossref texlive
+pip install pandoc-acro pandoc-include --user
 ```
 
 [docker-image]: https://hub.docker.com/r/siphalor/extended-pandoc

--- a/index.md
+++ b/index.md
@@ -118,6 +118,22 @@ scoop install tinytex
 pip install pandoc pandoc-acro pandoc-include pandoc-crossref --user
 ```
 
+### Linux
+
+Start terminal
+
+**If python is (for some bizarre reason) not installed**
+```bash
+apt install python
+python -m ensure pip
+```
+(`apt` is for ubuntu, replace with `yum`, `pacman`, `dnf`, `apk`, `apt-get`, or `zypper` as needed)
+
+```bash
+sudo apt install texlive-full
+pip install pandoc pandoc-acro pandoc-include pandoc-crossref --user
+```
+
 [docker-image]: https://hub.docker.com/r/siphalor/extended-pandoc
 
 # Demo

--- a/index.md
+++ b/index.md
@@ -80,7 +80,7 @@ Unter Linux kann folgender Befehl zum Kompilieren der PDF mit Docker verwendet w
 
 ```sh
 docker run --rm --volume $(pwd):/data --entrypoint make siphalor/extended-pandoc
-``` 
+```
 
 ## Manuell
 
@@ -114,17 +114,22 @@ scoop install uutils-coreutils
 ```
 
 Abschließend werden jetzt die Pandoc- und Latex-Umgebung installiert.
-In den folgenden Befehlen wird [TinyTeX](https://github.com/rstudio/tinytex), eine [TeX-Live][https://tug.org/texlive/]-Distribution, verwendet.  
+In den folgenden Befehlen wird [TinyTeX](https://github.com/rstudio/tinytex), eine [TeX-Live](https://tug.org/texlive/)-Distribution, verwendet.
 Anstelle von `tinytex` kann auch [MikTex](https://miktex.org/howto/install-miktex) (bei Scoop als `miktex`) verwendet werden.
 Dies bietet unter anderem eine grafische Oberfläche und eine einsteigerfreundlichere Paket-Verwaltung.
 
-```pwsh 
+```pwsh
 # texlive installation
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
 scoop install tinytex
 # pandoc installation
 scoop install pandoc pandoc-crossref
 pip install pandoc-acro pandoc-include --user
+```
+
+[SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) können mit GNOME `librsvg` Eingebettet werden. Windows muss diese Library Nachtbeziehen.
+```pwsh
+scoop install https://gist.githubusercontent.com/LuminousPath/55c9a416ab8530cd5875e29e8197f22c/raw/fa5ef794486acfa3d130028b9626d24c7d1ed5ad/rsvg-convert.json
 ```
 
 ### Linux
@@ -143,6 +148,11 @@ Schlussendlich können Pandoc, die nötigen Extensions und die [TeX Live][texliv
 ```bash
 brew install pandoc pandoc-crossref texlive
 pip install pandoc-acro pandoc-include --user
+```
+
+[SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) können mit GNOME `librsvg` Eingebettet werden. Die Library ist auf einigen Distos bereits installiert, ansonsten muss die Library bezogen werden.
+```pwsh
+brew install librsvg
 ```
 
 [docker-image]: https://hub.docker.com/r/siphalor/extended-pandoc
@@ -220,7 +230,7 @@ Durch Extensions wird zusätzliche Funktionalität zur Verfügung gestellt:
       dhbw:
         short: DHBW
     ```
-  
+
     Und anschließend verwendet werden: +dhbw; [+dhbw]{.long}
 
 [`pandoc-crossref`](https://github.com/lierdakil/pandoc-crossref) --- Referenzen:

--- a/index.md
+++ b/index.md
@@ -111,7 +111,7 @@ Zu gut der Letzt benötigen wir noch Makefiles `make` command aus den GNU core u
 scoop install uutils-coreutils
 ```
 
-Jetzt werden die `pandoc` Abhängigkeiten und eine Latex engine, hier `tinytex` eine `texlive` distribution, eingesetzt. Der nicht Konsolen-Freund sollte anstatt `tinytex` [MikTex](https://miktex.org/howto/install-miktex) als Benutzer installieren, das macht das verwalten von LaTex packages angenehmer.
+Jetzt werden die [pandoc](https://pandoc.org/) Abhängigkeiten und eine Latex engine, hier [tinytex](https://github.com/rstudio/tinytex) eine [texlive](https://tug.org/texlive/) distribution, eingesetzt. Der nicht Konsolen-Freund sollte anstatt `tinytex` [MikTex](https://miktex.org/howto/install-miktex) als Benutzer installieren, das macht das verwalten von LaTex packages angenehmer.
 
 ```pwsh 
 # texlive installation

--- a/index.md
+++ b/index.md
@@ -114,24 +114,27 @@ scoop install uutils-coreutils
 Now for the actual installation execute the following commands (tinytex ist a texlive distribution)
 ```pwsh 
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
-scoop install tinytex
-pip install pandoc pandoc-acro pandoc-include pandoc-crossref --user
+scoop install tinytex pandoc pandoc-crossref
+pip install pandoc-acro pandoc-include --user
 ```
 
 ### Linux
 
 Start terminal
 
-**If python is (for some bizarre reason) not installed**
+**If homebrew is not installed**
 ```bash
-apt install python
-python -m ensure pip
+test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)"
+test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+test -r ~/.bash_profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bash_profile
+echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.profile
 ```
-(`apt` is for ubuntu, replace with `yum`, `pacman`, `dnf`, `apk`, `apt-get`, or `zypper` as needed)
 
+Now for the actual installation execute the following commands
 ```bash
-sudo apt install texlive-full
-pip install pandoc pandoc-acro pandoc-include pandoc-crossref --user
+python -m ensure pip
+brew install pandoc-crossref texlive
+pip install pandoc pandoc-acro pandoc-include--user
 ```
 
 [docker-image]: https://hub.docker.com/r/siphalor/extended-pandoc

--- a/index.md
+++ b/index.md
@@ -90,6 +90,34 @@ Die Liste der Extensions findet sich in [der Readme des Docker-Images][docker-im
 Anschließend kann mit `make index.pdf` die PDF-Datei kompiliert werden.
 Unter Windows kann sich der entsprechende Befehl aus dem `Makefile` entnommen werden.
 
+### Windows
+
+Start powershell
+
+**If scoop is not installed**
+```pwsh
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+irm get.scoop.sh | iex
+```
+
+**If python is not installed**
+```pwsh
+scoop install python
+python -m ensure pip
+```
+
+**If GNU make is not available** (Rust implementation of GNU core utils)
+```pwsh
+scoop install uutils-coreutils
+```
+
+Now for the actual installation execute the following commands (tinytex ist a texlive distribution)
+```pwsh 
+scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
+scoop install tinytex
+pip install pandoc pandoc-acro pandoc-include pandoc-crossref --user
+```
+
 [docker-image]: https://hub.docker.com/r/siphalor/extended-pandoc
 
 # Demo
@@ -130,7 +158,7 @@ Unterstützt werden alle typischen Markdown-Features, sowie die nativen Erweiter
 
   | Spalte 1 | Spalte 2 | Spalte 3 |
   | :------- | :------: | -------: |
-  | A        | B        | C        |
+  | A        |    B     |        C |
   : Tabellen-Beschriftung {#tbl:some-table}
 
 - `Code` und Code-Blöcke:

--- a/index.md
+++ b/index.md
@@ -55,7 +55,7 @@ colorlinks: true # Colorize links, useful for the digital version
 
 # Einleitung
 
-Eine Vorlage, um wissenschaftliche Arbeiten für die +dhbw in Pandoc verfassen zu können.
+Eine Vorlage, um wissenschaftliche Arbeiten für die +dhbw in [Pandoc](https://pandoc.org) verfassen zu können.
 
 Dabei werden die in [@DHBW.2021] beschriebenen Richtlinien nach bestem Gewissen umgesetzt.
 
@@ -92,26 +92,31 @@ Unter Windows kann sich der entsprechende Befehl aus dem `Makefile` entnommen we
 
 ### Windows
 
-Im folgenden wird die installation unter Windows beschrieben. Zunächst öffnen wir eine Powershell Sitzung, vorzüglich [pwsh](https://github.com/powershell/powershell), denn die Microsoft proprietäre Implementierung ist besonders. 
+Im Folgenden wird die Installation unter Windows beschrieben.
+Die folgenden Befehle sollten in PowerShell ausgeführt werden (alternativ [pwsh](https://github.com/powershell/powershell)).
 
-Als package-manager wird scoop genutzt, denn der benötigt keine administrativen Rechte.
+Als Package Manager wird Scoop genutzt, da dieser einfache Installationen und Updates ohne administrative Rechte ermöglicht.
 ```pwsh
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 irm get.scoop.sh | iex
 ```
 
-Mit Pip werden die nicht auf scoop auffindbaren packages installiert.
+Weiterhin wird `pip` benötigt um die Python-basierten Extensions zu installieren:
 ```pwsh
 scoop install python
-python -m ensure pip
+python -m ensurepip
 ```
 
-Zu gut der Letzt benötigen wir noch Makefiles `make` command aus den GNU core utils. Hier verwenden wir die Rust Implementation.
+Nun benötigen wir noch den `make` command aus den GNU coreutils.
+Hier kann beispielsweise die Rust-Implementierung dieser Tools verwendet werden:
 ```pwsh
 scoop install uutils-coreutils
 ```
 
-Jetzt werden die [pandoc](https://pandoc.org/) Abhängigkeiten und eine Latex engine, hier [tinytex](https://github.com/rstudio/tinytex) eine [texlive](https://tug.org/texlive/) distribution, eingesetzt. Der nicht Konsolen-Freund sollte anstatt `tinytex` [MikTex](https://miktex.org/howto/install-miktex) als Benutzer installieren, das macht das verwalten von LaTex packages angenehmer.
+Abschließend werden jetzt die Pandoc- und Latex-Umgebung installiert.
+In den folgenden Befehlen wird [TinyTeX](https://github.com/rstudio/tinytex), eine [TeX-Live][https://tug.org/texlive/]-Distribution, verwendet.  
+Anstelle von `tinytex` kann auch [MikTex](https://miktex.org/howto/install-miktex) (bei Scoop als `miktex`) verwendet werden.
+Dies bietet unter anderem eine grafische Oberfläche und eine einsteigerfreundlichere Paket-Verwaltung.
 
 ```pwsh 
 # texlive installation
@@ -124,23 +129,24 @@ pip install pandoc-acro pandoc-include --user
 
 ### Linux
 
-Zunächst den [homebrew](https://brew.sh/) ~~package~~-manager installieren.
+Der Einfachheit halber am besten zunächst den [Homebrew](https://brew.sh/) Package Manager installieren:
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-Falls `pip` nicht installiert ist `python` `pip` beziehen. `python3` ist manchmal auch nur `python` o.ä. kommt auf Eur setup an.
+Python ist in den allermeisten Linux-Distributionen vorinstalliert, eventuell ist es als `python` statt `python3` verfügbar:
 ```bash
-python3 -m ensure pip
+python3 -m ensurepip
 ```
 
-Zu gut der Letzt können die [pandoc](https://pandoc.org/) Abhängigkeiten und die [texlive](https://tug.org/texlive/) LaTex engine installiert werden.
+Schlussendlich können Pandoc, die nötigen Extensions und die [TeX Live][texlive] LaTeX-Umgebung installiert werden.
 ```bash
 brew install pandoc pandoc-crossref texlive
 pip install pandoc-acro pandoc-include --user
 ```
 
 [docker-image]: https://hub.docker.com/r/siphalor/extended-pandoc
+[texlive]: https://tug.org/texlive/
 
 # Demo
 

--- a/index.md
+++ b/index.md
@@ -47,6 +47,8 @@ babel-otherlangs:
 
 colorlinks: true # Colorize links, useful for the digital version
 
+roman-numerals: true # Use roman numerals for content tables
+
 # lot: true # Enable list of tables
 # lof: true # Enable list of figures
 # lol: true # Enable list of listings
@@ -207,7 +209,7 @@ Unterstützt werden alle typischen Markdown-Features, sowie die nativen Erweiter
   ```python
   print("Hello World");
   ```
-  
+
   ```{.python caption="Ein Code-Block der nicht im Fließtext ist!" #lst:floating-code-block}
   print("Floating Code Block!")
   ```

--- a/pandoc/template.latex
+++ b/pandoc/template.latex
@@ -338,6 +338,15 @@ $endif$
 $if(pagestyle)$
 \pagestyle{$pagestyle$}
 $endif$
+
+$if(index-roman)$
+% use roman numerals for ordering
+\usepackage{tocloft}
+\setlength{\cftchapnumwidth}{1.5em}
+\cftsetindents{section}{1.5em}{3.5em}
+\cftsetindents{subsection}{1.5em}{5em}
+$endif$ %(index-roman)
+
 $if(csl-refs)$
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
@@ -460,12 +469,12 @@ $endif$ %(pagemark)
 
 \begin{document}
 
-$if(roman-numerals)$
-% use roman numerals for ordering
+$if(index-roman)$
+% use roman numerals for ordering in content tables
 \renewcommand{\thechapter}{\Roman{chapter}}
 \renewcommand{\thesection}{\thechapter.\Roman{section}}
 \renewcommand{\thesubsection}{\thesection.\Roman{subsection}}
-$endif$ %(roman-numerals)
+$endif$ %(index-roman)
 
 $if(has-frontmatter)$
 \frontmatter
@@ -587,12 +596,17 @@ $include-before$
 
 $endfor$
 
-$if(roman-numerals)$
+$if(content-table.index.roman)$
 % use roman numerals for ordering
 \renewcommand{\thechapter}{\Roman{chapter}}
 \renewcommand{\thesection}{\thechapter.\Roman{section}}
 \renewcommand{\thesubsection}{\thesection.\Roman{subsection}}
-$endif$ %(roman-numerals)
+$endif$ %(content-table.index.roman)
+
+$if(pagemark-roman)$
+% use roman numerals for page numbers in content tables
+\pagenumbering{Roman}
+$endif$ %(pagemark-roman)
 
 $if(toc)$
 $if(toc-title)$

--- a/pandoc/template.latex
+++ b/pandoc/template.latex
@@ -440,6 +440,14 @@ $endif$
 $endif$
 
 \begin{document}
+
+$if(roman-numerals)$
+% use roman numerals for ordering
+\renewcommand{\thechapter}{\Roman{chapter}}
+\renewcommand{\thesection}{\thechapter.\Roman{section}}
+\renewcommand{\thesubsection}{\thesection.\Roman{subsection}}
+$endif$ %(roman-numerals)
+
 $if(has-frontmatter)$
 \frontmatter
 $endif$
@@ -559,6 +567,14 @@ $for(include-before)$
 $include-before$
 
 $endfor$
+
+$if(roman-numerals)$
+% use roman numerals for ordering
+\renewcommand{\thechapter}{\Roman{chapter}}
+\renewcommand{\thesection}{\thechapter.\Roman{section}}
+\renewcommand{\thesubsection}{\thesection.\Roman{subsection}}
+$endif$ %(roman-numerals)
+
 $if(toc)$
 $if(toc-title)$
 \renewcommand*\contentsname{$toc-title$}
@@ -595,6 +611,7 @@ $endif$
 $if(has-frontmatter)$
 \mainmatter
 $endif$
+
 $body$
 
 $if(has-frontmatter)$

--- a/pandoc/template.latex
+++ b/pandoc/template.latex
@@ -370,7 +370,6 @@ $if(lang)$
 \usepackage[bidi=default]{babel}
 \fi
 \babelprovide[main,import]{$babel-lang$}
-\babelprovide[import]{english}
 $for(babel-otherlangs)$
 \babelprovide[import]{$babel-otherlangs$}
 $endfor$
@@ -485,7 +484,7 @@ $else$
 			\bfseries Betreuer*in des Dualen Partners    & $company-tutor$               \\
 			$endif$
 			$if(university-tutor)$
-			\bfseries Gutachter*in der Dualen Hochschule & $university-tutor$           
+			\bfseries Gutachter*in der Dualen Hochschule & $university-tutor$
 			$endif$
 			\end{tabular}
 			\end{table}

--- a/pandoc/template.latex
+++ b/pandoc/template.latex
@@ -439,6 +439,25 @@ $if(logo)$
 $endif$
 $endif$
 
+\usepackage{scrlayer-scrpage}
+$if(footer.pagemark.left)$
+$if(footer.authors)$
+\lofoot*{$for(author)$$author$ $sep$ $endfor$} %\@author
+$endif$ %(footer.authors)
+\cofoot*{}
+\rofoot*{\pagemark}
+$elseif(footer.pagemark.right)$
+\lofoot*{\pagemark}
+\cofoot*{}
+$if(footer.authors)$
+\rofoot*{$for(author)$$author$ $sep$ $endfor$} %\@author
+$endif$ %(footer.authors)
+$else$
+$if(footer.authors)$
+\cofoot*{$for(author)$$author$ $sep$ $endfor$} %\@author
+$endif$ %(footer.authors)
+$endif$ %(pagemark)
+
 \begin{document}
 
 $if(roman-numerals)$


### PR DESCRIPTION
The specification document of the DHBW Mosbach, defines that the pagemark should be located on the right side of the page, and the author names on the left side.
This pr implements this, while allowing to reset to the previous layout, by commenting
```yaml
  pagemark:
    left: true
  authors: true 
```
in [index.md](./index.md).